### PR TITLE
Deploy.sh and two other minor tweaks.

### DIFF
--- a/etl/hmda_template/HMDAFileIngestionDataPipelines_CreateStack.sh
+++ b/etl/hmda_template/HMDAFileIngestionDataPipelines_CreateStack.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-aws cloudformation create-stack --stack-name HMDADataIngestionDataPipelines --template-url https://s3.amazonaws.com/datalake-poc-matt/feeds/hmda/hmda_lar/scripts/deployment/HMDAFileIngestionDataPipelines.yaml --parameters file:///Users/mattroberts/Documents/GitHub/datalake-poc/etl/hmda_template/HMDAFileIngestionDataPipelines_CreateStack_Parameters.json --profile datalake
+aws cloudformation create-stack --stack-name HMDADataIngestionDataPipelines --template-url https://s3.amazonaws.com/datalake-poc-matt/feeds/hmda/hmda_lar/scripts/deployment/HMDAFileIngestionDataPipelines.yaml --parameters file://HMDAFileIngestionDataPipelines_CreateStack_Parameters.json --profile datalake

--- a/etl/hmda_template/deploy.sh
+++ b/etl/hmda_template/deploy.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+echo "Uploading files to S3"
+./upload_script_files.sh
+
+echo "Deploying SupportIAMRoles"
+aws cloudformation create-stack --stack-name SupportIAMRoles --template-url https://s3.amazonaws.com/datalake-poc-matt/feeds/hmda/hmda_lar/scripts/deployment/SupportIAMRoles.yaml --capabilities CAPABILITY_NAMED_IAM --profile datalake
+aws cloudformation wait stack-create-complete --stack-name SupportIAMRoles --profile datalake
+if test "$?" != "0"
+then
+    echo "SupportIAMRoles Did Not Return in a Timely Manner"
+    exit $?
+fi
+
+echo "Deploying SupportLambdaFunctions"
+aws cloudformation create-stack --stack-name SupportLambdaFunctions --template-url https://s3.amazonaws.com/datalake-poc-matt/feeds/hmda/hmda_lar/scripts/deployment/SupportLambdaFunctions.yaml --profile datalake
+aws cloudformation wait stack-create-complete --stack-name SupportLambdaFunctions --profile datalake
+if test "$?" != "0"
+then
+    echo "SupportLambdaFunctions Did Not Return in a Timely Manner"
+    exit $?
+fi
+
+echo "Deploying SupportSNSTopics"
+aws cloudformation create-stack --stack-name SupportSNSTopics --template-url https://s3.amazonaws.com/datalake-poc-matt/feeds/hmda/hmda_lar/scripts/deployment/SupportSNSTopics.yaml --profile datalake
+aws cloudformation wait stack-create-complete --stack-name SupportSNSTopics --profile datalake
+if test "$?" != "0"
+then
+    echo "SupportSNSTopics Did Not Return in a Timely Manner"
+    exit $?
+fi
+
+echo "Deploying HMDADataIngestionDataPipelines"
+aws cloudformation create-stack --stack-name HMDADataIngestionDataPipelines --template-url https://s3.amazonaws.com/datalake-poc-matt/feeds/hmda/hmda_lar/scripts/deployment/HMDAFileIngestionDataPipelines.yaml --parameters file://HMDAFileIngestionDataPipelines_CreateStack_Parameters.json --profile datalake
+aws cloudformation wait stack-create-complete --stack-name HMDADataIngestionDataPipelines --profile datalake
+if test "$?" != "0"
+then
+    echo "SupportSNSTopics Did Not Return in a Timely Manner"
+    exit $?
+fi
+
+echo "Everything Successful"
+echo "Don't forget to add an email address to the SNS topic using the following command: aws sns subscribe --topic-arn <topicarn> --protocol email --notification-endpoint <email_address>"

--- a/etl/hmda_template/upload_script_files.sh
+++ b/etl/hmda_template/upload_script_files.sh
@@ -11,6 +11,7 @@ aws s3 cp SupportIAMRoles_CreateStack.sh s3://datalake-poc-matt/feeds/hmda/hmda_
 aws s3 cp HMDAFileIngestionDataPipelines_CreateStack_Parameters.json s3://datalake-poc-matt/feeds/hmda/hmda_lar/scripts/deployment/HMDAFileIngestionDataPipelines_CreateStack_Parameters.json --profile datalake
 
 aws s3 cp upload_script_files.sh s3://datalake-poc-matt/feeds/hmda/hmda_lar/scripts/deployment/upload_script_files.sh --profile datalake
+aws s3 cp deploy.sh s3://datalake-poc-matt/feeds/hmda/hmda_lar/scripts/deployment/deploy.sh --profile datalake
 
 aws s3 cp hmda_convert_to_orc.sql s3://datalake-poc-matt/feeds/hmda/hmda_lar/scripts/hmda_convert_to_orc.sql --profile datalake
 aws s3 cp hmda_ingestion.py s3://datalake-poc-matt/feeds/hmda/hmda_lar/scripts/hmda_ingestion.py --profile datalake


### PR DESCRIPTION
Created deploy.sh that is a one-stop deployment script to deploy the entire hmda reference data ingestion process just by running one command.

Also includes a minor tweak to one of the reference cloudformation deployment scripts to use the relative path for the cloudformation parameters.  Also includes a minor tweak to the upload script to also upload the new deploy.sh file.